### PR TITLE
Override and update Apache HttpClient Fluent API from v4.5.3 to v4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<version.javadoc.plugin>3.1.0</version.javadoc.plugin>
 		<version.jackson>2.8.0</version.jackson>
 		<version.httpcore>4.4.6</version.httpcore>
-		<version.fluent-hc>4.5.3</version.fluent-hc>
+		<version.fluent-hc>4.5.13</version.fluent-hc>
 		<version.surefire>2.18</version.surefire>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<version.source.plugin>3.1.0</version.source.plugin>
 		<version.javadoc.plugin>3.1.0</version.javadoc.plugin>
 		<version.jackson>2.8.0</version.jackson>
-		<version.httpcore>4.4.6</version.httpcore>
+		<version.httpcore>4.4.13</version.httpcore>
 		<version.fluent-hc>4.5.13</version.fluent-hc>
 		<version.surefire>2.18</version.surefire>
 	</properties>


### PR DESCRIPTION
The update resolves:
* CVE-2020-13956 - Apache HttpClient can misinterpret malformed
authority component in request URIs